### PR TITLE
opdracht 3

### DIFF
--- a/deliverables/opdracht3/README.md
+++ b/deliverables/opdracht3/README.md
@@ -1,0 +1,27 @@
+# Playbook uitvoeren
+Draai het playbook met:
+
+``` bash
+ansible-playbook -i inventory.ini playbooks/03_multi_group.yml
+```
+
+## Variabelen
+De playbook taken gebruiken group_vars om pakketnamen en services te parametriseren:
+* **group_vars/app.yml**
+  * `app_package`: naam van het chrony-pakket (bijv. chrony).
+  * `app_service`: naam van de chrony-service (bijv. chronyd of chrony, afhankelijk van Distro).
+
+* **group_vars/db.yml**
+   * `db_package`: naam van het pakket voor de DB-groep (hier: curl).
+
+Zo kan hetzelfde playbook werken op verschillende distros door alleen de variabelen aan te passen.
+
+# Dry-run en observaties
+``` bash
+ansible-playbook -i inventory.ini playbooks/03_multi_group.yml --check
+```
+
+Observaties bij `--check`:
+
+* **Pakketinstallatie**: Ansible kan meestal voorspellen of er een wijziging nodig is, maar niet altijd (bijv. wanneer package metadata ontbreekt).
+* **Services**: In check-mode kan Ansible niet garanderen of een service daadwerkelijk gestart zou worden, het meldt alleen een verwachte wijziging.

--- a/group_vars/app.yml
+++ b/group_vars/app.yml
@@ -1,0 +1,2 @@
+app_package: chrony
+app_service: chronyd

--- a/group_vars/db.yml
+++ b/group_vars/db.yml
@@ -1,0 +1,1 @@
+db_package: curl

--- a/playbooks/03_multi_group.yml
+++ b/playbooks/03_multi_group.yml
@@ -1,0 +1,25 @@
+---
+- name: Configure app servers
+  hosts: app
+  become: true
+  tasks:
+    - name: Install chrony
+      ansible.builtin.package:
+        name: "{{ app_package }}"
+        state: present
+      tags: packages
+    - name: Ensure chrony service is running and enabled
+      ansible.builtin.service:
+        name: "{{ app_service }}"
+        state: started
+        enabled: true
+      tags: services
+- name: Configure db servers
+  hosts: db
+  become: true
+  tasks:
+    - name: Install curl
+      ansible.builtin.package:
+        name: "{{ db_package }}"
+        state: present
+      tags: packages


### PR DESCRIPTION
Voor opdracht 3 zijn de volgende onderdelen erbij gekomen:
* **playbook**: installeert curl/chrony en enabled de service
* **group_vars**: een directory waar per groep variabelen opgeslagen worden die in het playbook gebruikt worden
* **README.md**: legt uit welke variabelen er gebruikt worden en wat de observaties zijn bij het gebruik van `--check`